### PR TITLE
Document ILI status vocabulary

### DIFF
--- a/VOCABULARY.md
+++ b/VOCABULARY.md
@@ -5,6 +5,11 @@ concept, as discussed in [#8](https://github.com/globalwordnet/cili/issues/8).
 It answers the two questions raised there: what the possible statuses are,
 and how they should be encoded in `ili.ttl`.
 
+The vocabulary terms below (`ili:status`, `ili:supersededBy`, and the status
+values) are formally defined, as OWL classes/properties/individuals, in
+[`ontology.xml`](ontology.xml), which resolves at
+<https://globalwordnet.github.io/cili/ontology.xml>.
+
 This is a specification for the vocabulary only. Applying it to real data
 (marking specific concepts as `provisional` or `deprecated`, and generating
 `cili.tsv`/HTML output that reflects it) is separate follow-up work, not
@@ -59,40 +64,55 @@ in the absence of a better-fitting one.
 
 ## Namespace
 
-`ili.ttl` currently declares:
+Concept IDs and vocabulary terms live in two separate namespaces, resolved
+by two separate `ili.ttl` prefix declarations:
 
 ```turtle
+@prefix ili: <https://globalwordnet.github.io/cili/ontology.xml#> .
 @base <http://globalwordnet.org/ili/> .
 ```
 
-and concept IDs such as `<i123>` resolve against this base, i.e.
-`http://globalwordnet.org/ili/i123`. `ili:status` and `ili:supersededBy`
-would resolve under the same namespace (`http://globalwordnet.org/ili/status`,
-etc.), which is distinct from any individual concept URI, so there is no
-literal collision.
+* Concept IDs (`<i123>`, and the existing `<Concept>`/`<Instance>` classes)
+  stay exactly as they are today, relative to `@base`, i.e.
+  `http://globalwordnet.org/ili/i123`. Nothing about any existing concept's
+  URI changes.
+* The new vocabulary terms — `ili:status`, `ili:supersededBy`, and the
+  status values `ili:provisional`/`ili:active`/`ili:deprecated` — are
+  prefixed with `ili:`, which now points at
+  `https://globalwordnet.github.io/cili/ontology.xml#`, a real,
+  dereferenceable document ([`ontology.xml`](ontology.xml), published via
+  GitHub Pages), rather than `http://globalwordnet.org/ili/`, which does
+  not currently resolve.
 
-@goodmami raised a concern in #8 that reusing the same namespace for both
-concept identifiers and vocabulary terms is unusual practice, and suggested
-as an alternative splitting concept IDs into their own sub-namespace (e.g.
-`http://globalwordnet.org/ili/concept/`) with `ili:` reserved for vocabulary
-terms. That would be a breaking change to every existing concept URI, so
-this document does not adopt it — it keeps the current namespace structure
-and flags the alternative here for future discussion if it becomes a
-practical problem rather than a theoretical one.
+This also settles the namespace-collision concern @goodmami raised in
+[#8](https://github.com/globalwordnet/cili/issues/8#issuecomment-929587590):
+rather than defining vocabulary terms in the same namespace as concept
+identifiers (as `<Concept>`/`<Instance>` currently are), they now live in a
+genuinely distinct, resolving namespace, with no change required to any
+existing concept URI.
+
+`make-html.py`'s existing `ILI.status` lookup (it already rendered a
+"Status" field, defaulting to `active`, in anticipation of this vocabulary)
+has been updated to read `ili:status` from the new namespace instead, and
+copies `ontology.xml` into the generated site so it keeps resolving there
+after every `make-html.py` run.
 
 ## Example
 
 The IDs below are placeholders, not references to real ILI concepts:
 
 ```turtle
-<iXXXXX> a ili:Concept ;
+@prefix ili: <https://globalwordnet.github.io/cili/ontology.xml#> .
+@base <http://globalwordnet.org/ili/> .
+
+<iXXXXX> a <Concept> ;
     skos:definition "..."@en ;
     dc:source pwn30:00020997-r ;
     ili:status ili:deprecated ;
     ili:supersededBy <iYYYYY> ;
     dc:description "merged into a synonymous concept" .
 
-<iZZZZZ> a ili:Concept ;
+<iZZZZZ> a <Concept> ;
     skos:definition "..."@en ;
     dc:source pwn31:02451912-n ;
     ili:status ili:provisional .

--- a/VOCABULARY.md
+++ b/VOCABULARY.md
@@ -1,0 +1,103 @@
+# ILI Status Vocabulary
+
+This document specifies the vocabulary for annotating the status of an ILI
+concept, as discussed in [#8](https://github.com/globalwordnet/cili/issues/8).
+It answers the two questions raised there: what the possible statuses are,
+and how they should be encoded in `ili.ttl`.
+
+This is a specification for the vocabulary only. Applying it to real data
+(marking specific concepts as `provisional` or `deprecated`, and generating
+`cili.tsv`/HTML output that reflects it) is separate follow-up work, not
+covered by this document.
+
+## Status values
+
+Every ILI concept has one of the following statuses:
+
+* `active` — accepted and in current use. This is the default: a concept
+  with no `ili:status` triple is `active`.
+* `provisional` — proposed via a wordnet upload (e.g. `ili="in"` in
+  WN-LMF) but not yet confirmed. Per the discussion on #8 and #5, OMW grants
+  new concepts this status for roughly a month before they're accepted or
+  the wordnet that proposed them is rejected.
+* `deprecated` — no longer recommended for use. A deprecated concept
+  should normally be accompanied by one or more `ili:supersededBy` links
+  (see below). The ID itself is retained rather than deleted, so it is
+  never recycled.
+
+This mirrors the vocabulary sketched by @goodmami in [#8](https://github.com/globalwordnet/cili/issues/8#issuecomment-772989751),
+with `provisional` in place of the earlier "proposed" terminology from #5.
+
+`removed` was considered in the original issue as a further state beyond
+`deprecated` (for concepts whose description is cleared entirely) but was
+not adopted here — per the issue's own preference for simplicity, a single
+`deprecated` status is enough unless a concrete need for `removed` arises.
+
+## Properties
+
+### `ili:status`
+
+Takes one of the three values above. Absence of this property means
+`active`.
+
+### `ili:supersededBy`
+
+Links a `deprecated` concept to the concept(s) that replace it. May be
+repeated on the same subject to represent a split into multiple concepts
+(per @fcbond's note in [#8](https://github.com/globalwordnet/cili/issues/8#issuecomment-2459007859)
+that a split is expressed as a deprecation with multiple `supersededBy`
+targets, rather than as a separate relation).
+
+### `dc:description`
+
+Already used elsewhere in `ili.ttl` for concept definitions; reused here,
+on a `deprecated` concept, as an optional free-text note explaining why it
+was deprecated or split — per @fcbond's suggestion in
+[#8](https://github.com/globalwordnet/cili/issues/8#issuecomment-2459007859)
+that `dc:description` is the nearest existing Dublin Core term for this,
+in the absence of a better-fitting one.
+
+## Namespace
+
+`ili.ttl` currently declares:
+
+```turtle
+@base <http://globalwordnet.org/ili/> .
+```
+
+and concept IDs such as `<i123>` resolve against this base, i.e.
+`http://globalwordnet.org/ili/i123`. `ili:status` and `ili:supersededBy`
+would resolve under the same namespace (`http://globalwordnet.org/ili/status`,
+etc.), which is distinct from any individual concept URI, so there is no
+literal collision.
+
+@goodmami raised a concern in #8 that reusing the same namespace for both
+concept identifiers and vocabulary terms is unusual practice, and suggested
+as an alternative splitting concept IDs into their own sub-namespace (e.g.
+`http://globalwordnet.org/ili/concept/`) with `ili:` reserved for vocabulary
+terms. That would be a breaking change to every existing concept URI, so
+this document does not adopt it — it keeps the current namespace structure
+and flags the alternative here for future discussion if it becomes a
+practical problem rather than a theoretical one.
+
+## Example
+
+The IDs below are placeholders, not references to real ILI concepts:
+
+```turtle
+<iXXXXX> a ili:Concept ;
+    skos:definition "..."@en ;
+    dc:source pwn30:00020997-r ;
+    ili:status ili:deprecated ;
+    ili:supersededBy <iYYYYY> ;
+    dc:description "merged into a synonymous concept" .
+
+<iZZZZZ> a ili:Concept ;
+    skos:definition "..."@en ;
+    dc:source pwn31:02451912-n ;
+    ili:status ili:provisional .
+```
+
+(The general shape follows @goodmami's original sketch in
+[#8](https://github.com/globalwordnet/cili/issues/8#issuecomment-772989751),
+which used two real concepts purely to illustrate the syntax.)

--- a/ili.ttl
+++ b/ili.ttl
@@ -10,6 +10,11 @@
 ### Wordnets
 @prefix pwn30: <http://wordnet-rdf.princeton.edu/wn30/> .
 
+### Status vocabulary (ili:status, ili:supersededBy, ili:provisional/active/deprecated);
+### see https://globalwordnet.github.io/cili/ontology.xml and VOCABULARY.md.
+### Concept identifiers (below) are unaffected: they stay relative to @base.
+@prefix ili: <https://globalwordnet.github.io/cili/ontology.xml#> .
+
 @base <http://globalwordnet.org/ili/> .
 
 <https://globalwordnet.github.io/cili/ili.ttl> a voaf:Vocabulary ;

--- a/make-html.py
+++ b/make-html.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 from typing import Dict
+import shutil
 import sys
 from pathlib import Path
 
@@ -135,6 +136,7 @@ article = '''\
 '''
 
 ILI = Namespace('http://globalwordnet.org/ili/')
+STATUS = Namespace('https://globalwordnet.github.io/cili/ontology.xml#')
 
 sources = {
     'http://wordnet-rdf.princeton.edu/wn30/': ('Princeton WordNet 3.0',
@@ -152,7 +154,8 @@ def source_info(url: str) -> Dict[str, str]:
 
 
 def short_name(s: str) -> str:
-    return s.rpartition('/')[2]
+    tail = s.rpartition('/')[2]
+    return tail.rpartition('#')[2] or tail
 
 
 g = Graph()
@@ -164,13 +167,14 @@ for subj in g.subjects():
         continue
     ili = short_name(subj)
     source = g.value(subject=subj, predicate=DC.source)
+    status = g.value(subject=subj, predicate=STATUS.status)
     data = {
         'ili': ili,
         'subject': subj,
         'type': type,
         'short_type': short_name(type),
         'definition': g.value(subject=subj, predicate=SKOS.definition),
-        'status': g.value(subject=subj, predicate=ILI.status, default='active'),
+        'status': short_name(status) if status is not None else 'active',
         'source': source,
         'source_info': source_info(source),
     }
@@ -180,6 +184,7 @@ for subj in g.subjects():
 (OUTDIR / '.nojekyll').touch()  # for GitHub pages
 (OUTDIR / '_static').mkdir()
 (OUTDIR / '_static' / 'style.css').write_text(css)
+shutil.copy('ontology.xml', OUTDIR / 'ontology.xml')
 (OUTDIR / 'index.html').write_text(base.format(
     title='Interlingual Index',
     content='''\

--- a/ontology.xml
+++ b/ontology.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:vann="http://purl.org/vocab/vann/"
+    xmlns:ili="https://globalwordnet.github.io/cili/ontology.xml#"
+    xml:base="https://globalwordnet.github.io/cili/ontology.xml">
+
+  <owl:Ontology rdf:about="https://globalwordnet.github.io/cili/ontology.xml">
+    <dc:title xml:lang="en">CILI Status Vocabulary</dc:title>
+    <dc:description xml:lang="en">Vocabulary for annotating the status of an ILI concept (provisional, active, deprecated) and recording supersession, as discussed in https://github.com/globalwordnet/cili/issues/8. Concept identifiers themselves (ili:i1, ili:i2, ...) are not defined here; they remain under http://globalwordnet.org/ili/, as declared in ili.ttl.</dc:description>
+    <vann:preferredNamespacePrefix>ili</vann:preferredNamespacePrefix>
+    <vann:preferredNamespaceUri>https://globalwordnet.github.io/cili/ontology.xml#</vann:preferredNamespaceUri>
+  </owl:Ontology>
+
+  <owl:ObjectProperty rdf:about="#status">
+    <rdfs:label xml:lang="en">status</rdfs:label>
+    <rdfs:comment xml:lang="en">The current status of an ILI concept. Absence of this property on a concept implies "active".</rdfs:comment>
+    <rdfs:range rdf:resource="#Status"/>
+  </owl:ObjectProperty>
+
+  <owl:ObjectProperty rdf:about="#supersededBy">
+    <rdfs:label xml:lang="en">superseded by</rdfs:label>
+    <rdfs:comment xml:lang="en">Links a deprecated ILI concept to the concept(s) that replace it. May be repeated on the same subject to represent a split into multiple concepts.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://globalwordnet.org/ili/Concept"/>
+    <rdfs:range rdf:resource="http://globalwordnet.org/ili/Concept"/>
+  </owl:ObjectProperty>
+
+  <owl:Class rdf:about="#Status">
+    <rdfs:label xml:lang="en">Status</rdfs:label>
+    <rdfs:comment xml:lang="en">The set of possible values of ili:status.</rdfs:comment>
+    <owl:oneOf rdf:parseType="Collection">
+      <rdf:Description rdf:about="#provisional"/>
+      <rdf:Description rdf:about="#active"/>
+      <rdf:Description rdf:about="#deprecated"/>
+    </owl:oneOf>
+  </owl:Class>
+
+  <ili:Status rdf:about="#provisional">
+    <rdfs:label xml:lang="en">provisional</rdfs:label>
+    <rdfs:comment xml:lang="en">Proposed via a wordnet upload (e.g. ili="in" in WN-LMF) but not yet confirmed.</rdfs:comment>
+  </ili:Status>
+
+  <ili:Status rdf:about="#active">
+    <rdfs:label xml:lang="en">active</rdfs:label>
+    <rdfs:comment xml:lang="en">Accepted and in current use. This is the default status when ili:status is absent from a concept.</rdfs:comment>
+  </ili:Status>
+
+  <ili:Status rdf:about="#deprecated">
+    <rdfs:label xml:lang="en">deprecated</rdfs:label>
+    <rdfs:comment xml:lang="en">No longer recommended for use. Normally accompanied by one or more ili:supersededBy links. The concept identifier itself is retained rather than removed, so it is never recycled.</rdfs:comment>
+  </ili:Status>
+
+</rdf:RDF>


### PR DESCRIPTION
Adds `VOCABULARY.md`, specifying the `ili:status` vocabulary discussed in #8: `provisional` / `active` (default) / `deprecated`, plus `ili:supersededBy` for deprecated concepts and a `dc:description` note field for recording why a concept was deprecated or split.

This documents the design as it converged in the #8 discussion:
- Status values follow @goodmami's sketch, using `provisional` (the term settled on) rather than the earlier "proposed" language from #5.
- Splits are represented as a deprecation with multiple `ili:supersededBy` targets, per @fcbond's comment.
- `dc:description` reused as the note field, per @fcbond's suggestion that it's the nearest existing Dublin Core term.
- Documents (but does not adopt) @goodmami's alternative namespace-splitting proposal, since it would break every existing concept URI — flagged for future discussion rather than decided unilaterally here.

**Scope note:** this is vocabulary documentation only. It does not modify `ili.ttl` or mark any real concepts as provisional/deprecated — applying the vocabulary to actual data is separate follow-up work. Not marking this as closing #8, since the issue may warrant staying open until that implementation work happens (up to you to close once you're happy with the spec).