### PR TITLE
Add propose-ili.py: propose new ILIs via pull requests (#9, Phase 1)

### DIFF
--- a/.github/workflows/validate-ili-proposal.yml
+++ b/.github/workflows/validate-ili-proposal.yml
@@ -1,0 +1,69 @@
+name: Validate ILI Proposal
+
+# Runs validate-ili-proposal.py (issue #9, Phase 2) against any PR that
+# touches ili.ttl, and posts (or updates) a single advisory comment
+# summarizing the result. See PROPOSING_ILIS.md for the full workflow
+# this is part of.
+#
+# This only has access to the diff, not the contributor's original
+# WN-LMF file, so it re-checks a narrower set of things than
+# propose-ili.py itself does locally - see the comment's own text for
+# what's covered and what isn't.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'ili.ttl'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Get ili.ttl as it exists on the target branch
+        run: git show "origin/${{ github.base_ref }}:ili.ttl" > /tmp/base-ili.ttl
+
+      - name: Diff ili.ttl against the target branch
+        run: |
+          git diff "origin/${{ github.base_ref }}" HEAD -- ili.ttl > /tmp/ili.diff || true
+
+      - name: Run validation
+        run: |
+          python3 validate-ili-proposal.py \
+            --base-ili /tmp/base-ili.ttl \
+            --head-ili ili.ttl \
+            --diff /tmp/ili.diff \
+            --output /tmp/comment.md
+
+      - name: Post or update comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          MARKER='<!-- ili-validation-report -->'
+
+          COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq "[.[] | select(.body | startswith(\"$MARKER\"))] | last | .id // empty")
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -f body=@/tmp/comment.md
+          else
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" -X POST -f body=@/tmp/comment.md
+          fi

--- a/PROPOSING_ILIS.md
+++ b/PROPOSING_ILIS.md
@@ -7,10 +7,11 @@ previous informal process (a wordnet marks synsets `ili="in"`, and OMW
 maintainers "scoop them up" for offline review) with an ordinary, visible
 GitHub PR: a real diff, a discussion thread, and a review queue.
 
-This currently covers **proposing** and **reviewing** new concepts.
-Automated CI validation of proposal PRs is planned as a follow-up (see the
-open items at the end of this document) but doesn't exist yet — for now,
-review is manual.
+This covers **proposing** and **reviewing** new concepts. Once a PR
+touching `ili.ttl` is opened, a GitHub Actions workflow automatically
+posts a validation comment on it (see "Automated CI validation" under
+"For maintainers" below); a few other items are still manual or deferred
+(see "Not yet built" at the end of this document).
 
 ## For contributors
 
@@ -121,17 +122,47 @@ so this reallocates cleanly.
 Hard failures mean the candidate wasn't included in the fragment at all.
 Warnings mean it *was* included, but flagged for you to look at.
 
+### Automated CI validation
+
+[`.github/workflows/validate-ili-proposal.yml`](.github/workflows/validate-ili-proposal.yml)
+runs on every PR that touches `ili.ttl` and posts (or, on later pushes to
+the same PR, updates in place) a comment summarizing the result, via
+[`validate-ili-proposal.py`](validate-ili-proposal.py).
+
+It necessarily checks *less* than the contributor's local `propose-ili.py`
+run: a CI job only has the git history, not the contributor's original
+WN-LMF file, so it can't re-run the structural WN-LMF checks or the
+English-language heuristic. What it does check, using only `ili.ttl`
+before and after the PR:
+
+* **Shape** of every newly-added concept (correct `a <Concept>`/
+  `<Instance>`, an `@en`-tagged `skos:definition`, `dc:source`,
+  `ili:status ili:provisional`).
+* **ID collisions** — an added id that already exists on the target
+  branch, most likely because another proposal PR merged first.
+* **The same semantic duplicate check** propose-ili.py runs locally,
+  re-run against whatever is currently on the target branch (so it stays
+  accurate even if other proposals merged since the contributor last ran
+  the script).
+* Whether the diff **removes or modifies existing lines**, not just
+  appends new ones — flagged for a closer look, since a proposal PR
+  should normally be a pure append.
+
+It's advisory, not blocking — there's no branch protection requiring it
+to pass. Treat the comment the same way as the PR description's QC
+report: warnings are judgment calls, collisions and shape errors are
+worth resolving before merging.
+
 ### Reviewing a proposal PR
 
-* Read the QC report in the PR description. Warnings are judgment calls,
-  not blockers — use them to decide what to look at more closely.
-* Check the diff is a pure append to `ili.ttl` (nothing else touched,
-  nothing removed).
+* Read the QC report in the PR description, and the CI comment once it
+  posts — together they cover everything checked (see above for which
+  checks run where).
 * Every proposed concept should carry `ili:status ili:provisional` (see
   [VOCABULARY.md](VOCABULARY.md)) — that's expected and correct, not a
   mistake to fix before merging.
-* If you suspect an ID collision with something merged more recently,
-  ask the contributor to rerun the script against current `master`.
+* If CI flags an ID collision, ask the contributor to rerun
+  `propose-ili.py` against current `master` and push again.
 
 ### Promoting provisional concepts
 
@@ -147,11 +178,10 @@ past that window, and delete the `ili:status` triple to promote them
 These were discussed in #9 but are deliberately out of scope for now —
 tracked as follow-up work, not silently dropped:
 
-* **CI validation on proposal PRs.** Right now, everything above is
-  manual. A GitHub Actions workflow that re-validates a proposal PR's
-  diff and posts the results as a PR comment is planned as a follow-up.
 * **Naisc-based taxonomic-neighbor comparison** (comparing a candidate's
   relations/hypernyms against similar existing concepts, not just its
   definition text) — a separate, externally-maintained tool; integrate
   once it has a stable callable interface.
 * **Automated provisional → active promotion.**
+* **Turning CI validation into a required/blocking check** — it's
+  advisory for now; the repo has no branch protection today.

--- a/PROPOSING_ILIS.md
+++ b/PROPOSING_ILIS.md
@@ -41,6 +41,14 @@ requirements.txt`), and will download a small sentence-embedding model
 (`sentence-transformers/all-MiniLM-L6-v2`, used for the duplicate check
 below) the first time it runs.
 
+**Known issue:** if this fails with `invalid or missing DOCTYPE
+declaration` even though your file looks like valid WN-LMF, check for
+leading whitespace before `<!DOCTYPE` on the file's second line (e.g. a
+pretty-printer indented it). `wn.lmf.load` only trims trailing whitespace
+from that line, not leading, so an indented DOCTYPE fails its exact-match
+check. Strip the indentation from that one line and try again — this was
+hit while testing against a real 3.1 wordnet export.
+
 The script:
 * Extracts every `ili="in"` synset and its proposed definition.
 * Runs a battery of quality checks (see "What gets checked" below).

--- a/PROPOSING_ILIS.md
+++ b/PROPOSING_ILIS.md
@@ -1,0 +1,149 @@
+# Proposing New ILI Concepts
+
+This document describes how to propose new ILI concepts by opening a pull
+request against `ili.ttl`, as discussed in
+[#9](https://github.com/globalwordnet/cili/issues/9). It replaces the
+previous informal process (a wordnet marks synsets `ili="in"`, and OMW
+maintainers "scoop them up" for offline review) with an ordinary, visible
+GitHub PR: a real diff, a discussion thread, and a review queue.
+
+This currently covers **proposing** and **reviewing** new concepts.
+Automated CI validation of proposal PRs is planned as a follow-up (see the
+open items at the end of this document) but doesn't exist yet — for now,
+review is manual.
+
+## For contributors
+
+### 1. Mark your candidate synsets
+
+In your wordnet's WN-LMF file, set `ili="in"` on each synset you're
+proposing, with an `<ILIDefinition>` child giving its proposed English
+gloss — this is the standard WN-LMF mechanism for an unresolved ILI
+proposal, not anything CILI-specific.
+
+### 2. Run `propose-ili.py`
+
+```
+python3 propose-ili.py WORDNET.xml WN_ID WN_URL > proposed.ttl
+```
+
+`WORDNET.xml` is your WN-LMF file. `WN_ID` is a short identifier for your
+wordnet (e.g. `oewn`); `WN_URL` is a base URL used to build a `dc:source`
+link for each proposed concept (your synset's local WN-LMF id is appended
+to it), e.g.:
+
+```
+python3 propose-ili.py oewn-2024.xml oewn http://en-word.net/id/ > proposed.ttl
+```
+
+This requires the packages in `requirements.txt` (`pip install -r
+requirements.txt`), and will download a small sentence-embedding model
+(`sentence-transformers/all-MiniLM-L6-v2`, used for the duplicate check
+below) the first time it runs.
+
+The script:
+* Extracts every `ili="in"` synset and its proposed definition.
+* Runs a battery of quality checks (see "What gets checked" below).
+* Allocates each surviving candidate the next available `iNNNNN` id.
+* Writes a Turtle fragment (`proposed.ttl` above) in `ili.ttl`'s existing
+  style, and a QC report to stderr (use `--report FILE` to write it to a
+  file instead).
+
+Rejected candidates are **not** included in the fragment — see the report
+for why.
+
+### 3. Open the pull request
+
+* Append `proposed.ttl` to the end of `ili.ttl` (`cat proposed.ttl >>
+  ili.ttl`).
+* Commit and push.
+* Open a PR against `master`. **Paste the QC report into the PR
+  description** — this is what a maintainer reviews against; don't just
+  link to it.
+
+### Keep proposals reasonably sized
+
+Please don't submit a single PR proposing thousands of concepts at once.
+As a rough guide, keep batches to roughly 100 candidates or so per PR. If
+you have a large backlog, split it into several PRs — this keeps each PR
+reviewable as an actual diff, which is the entire point of doing this
+through GitHub rather than offline. Oversized PRs will be sent back to be
+split up rather than reviewed as-is.
+
+### If your PR conflicts after another proposal merges
+
+IDs are allocated sequentially based on `ili.ttl` at the time you ran the
+script. If another proposal PR merges before yours, your candidates may
+have been assigned IDs that now already exist — `git` won't necessarily
+flag this as a merge conflict, since both changes are pure appends. If a
+maintainer flags an ID collision, just rerun `propose-ili.py` against the
+latest `master` and push again; it always allocates from the current file,
+so this reallocates cleanly.
+
+## For maintainers
+
+### What gets checked
+
+* Structural checks from `wn`'s own WN-LMF validator (missing/blank
+  definitions, non-unique ids, in-file duplicate ILIs or definitions,
+  etc.) — these are effectively free correctness checks and are treated
+  as hard failures.
+* Definition length (10–500 characters) — hard failure outside that
+  range.
+* A simple heuristic flag for definitions that don't look like English —
+  **warning only**, since `<ILIDefinition>` carries no language attribute
+  to check against, this is a guess and can false-positive.
+* A semantic duplicate check: each candidate definition is compared
+  (cosine similarity via MiniLM sentence embeddings) against every
+  existing `skos:definition` in `ili.ttl`, and matches above 0.95 (by
+  default; contributors can adjust with `--similarity-threshold`) are
+  flagged — **warning only**, not a hard failure.
+
+  **Read this warning for what it actually is.** At MiniLM's scale, a
+  0.95 threshold mostly catches near-verbatim or lightly-reworded reuse
+  of an existing definition (e.g. a synonym swapped here or there) — not
+  every genuine paraphrase. Two independently-written definitions of the
+  same concept can easily score well below 0.95 and still be real
+  duplicates. Treat a high score as a strong hint, and the absence of one
+  as no guarantee of novelty — it's not a substitute for judgment,
+  especially for fine-grained or closely-related senses (see the
+  discussion on PR #17 for a real example of two genuinely distinct PWN
+  synsets that were nearly indistinguishable by gloss alone).
+
+Hard failures mean the candidate wasn't included in the fragment at all.
+Warnings mean it *was* included, but flagged for you to look at.
+
+### Reviewing a proposal PR
+
+* Read the QC report in the PR description. Warnings are judgment calls,
+  not blockers — use them to decide what to look at more closely.
+* Check the diff is a pure append to `ili.ttl` (nothing else touched,
+  nothing removed).
+* Every proposed concept should carry `ili:status ili:provisional` (see
+  [VOCABULARY.md](VOCABULARY.md)) — that's expected and correct, not a
+  mistake to fix before merging.
+* If you suspect an ID collision with something merged more recently,
+  ask the contributor to rerun the script against current `master`.
+
+### Promoting provisional concepts
+
+Per the existing OMW process, a proposed concept is typically given
+roughly a month before being confirmed. There's no automation for this
+yet: periodically, grep `ili.ttl` for `ili:provisional`, review entries
+past that window, and delete the `ili:status` triple to promote them
+(absence of the triple means `active`, per
+[VOCABULARY.md](VOCABULARY.md)).
+
+## Not yet built
+
+These were discussed in #9 but are deliberately out of scope for now —
+tracked as follow-up work, not silently dropped:
+
+* **CI validation on proposal PRs.** Right now, everything above is
+  manual. A GitHub Actions workflow that re-validates a proposal PR's
+  diff and posts the results as a PR comment is planned as a follow-up.
+* **Naisc-based taxonomic-neighbor comparison** (comparing a candidate's
+  relations/hypernyms against similar existing concepts, not just its
+  definition text) — a separate, externally-maintained tool; integrate
+  once it has a stable callable interface.
+* **Automated provisional → active promotion.**

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ other resources.
 ## Development and Maintenance
 
 CILI is maintained by the [Open Multilingual Wordnet][OMW]. Please see
-its [CILI page][CILI] for more information about the project,
-including how to propose new concepts.
+its [CILI page][CILI] for more information about the project. To propose
+new ILI concepts, see [PROPOSING_ILIS.md](PROPOSING_ILIS.md).
 
 [OMW]: https://omwn.org/
 [CILI]: https://compling.upol.cz/omw/ili

--- a/make-html.py
+++ b/make-html.py
@@ -150,7 +150,15 @@ def source_info(url: str) -> Dict[str, str]:
             local = url.removeprefix(src).lstrip('/#')
             name, project_url = sources[src]
             return {'name': name, 'url': project_url, 'local': local}
-    raise LookupError(f'source info not found for {url!s}')
+    # Unrecognized source (e.g. a newly proposed wordnet not yet added to
+    # `sources` above, per PROPOSING_ILIS.md): fall back to showing the
+    # source's own origin rather than crashing the whole site build.
+    scheme_and_host = '/'.join(url.split('/', 3)[:3]) + '/'
+    return {
+        'name': scheme_and_host,
+        'url': scheme_and_host,
+        'local': url.removeprefix(scheme_and_host),
+    }
 
 
 def short_name(s: str) -> str:

--- a/propose-ili.py
+++ b/propose-ili.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+
+"""
+Script to extract candidate ILI concepts from a WN-LMF wordnet file.
+
+Reads a wordnet's ili="in" synsets (i.e. synsets whose author has
+proposed them for a new ILI, per the WN-LMF spec), quality-checks them,
+allocates new sequential ILI identifiers, and writes a Turtle fragment
+in ili.ttl's existing style, ready to be appended to ili.ttl and opened
+as a pull request. Also writes a QC report meant to be pasted into that
+PR's description.
+
+See PROPOSING_ILIS.md for the full proposal workflow this script is
+part of (issue #9). This script does not touch git or GitHub; append
+its output to ili.ttl, commit, and open the PR yourself.
+
+Requirements:
+    - Python 3.6+
+    - rdflib
+    - wn
+    - sentence-transformers
+Usage:
+    python3 propose-ili.py WORDNET.xml WN_ID WN_URL > proposed.ttl
+Example:
+    python3 propose-ili.py oewn-2024.xml oewn http://en-word.net/id/ > proposed.ttl
+
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+from rdflib import Graph
+from rdflib.namespace import SKOS
+
+import wn.lmf
+import wn.validate
+
+MIN_DEFINITION_LENGTH = 10
+MAX_DEFINITION_LENGTH = 500
+DEFAULT_SIMILARITY_THRESHOLD = 0.95
+MINILM_MODEL = 'sentence-transformers/all-MiniLM-L6-v2'
+
+# wn.validate check codes we run against the submitted file. See
+# https://wn.readthedocs.io/en/latest/api/wn.validate.html for what each
+# one means; the subset picked here is the part of goodmami's requested
+# "first-pass quality control" that wn.validate already implements.
+STRUCTURAL_CHECKS = ('E101', 'W301', 'W302', 'W303', 'W304', 'W305', 'W306', 'W307')
+
+# Checks that mean we can't safely turn the candidate into an ILI at all.
+HARD_FAIL_CODES = {'E101', 'W303'}
+
+# A deliberately simple, non-authoritative heuristic: ILIDefinition
+# elements carry no language attribute (unlike regular Definitions), so
+# this can only ever be a hint for a maintainer to double-check, never a
+# hard-fail.
+_COMMON_ENGLISH_WORDS = {
+    'a', 'an', 'the', 'of', 'to', 'in', 'is', 'are', 'that', 'or', 'for',
+    'and', 'with', 'as', 'by', 'on', 'not', 'at', 'from', 'be', 'having',
+    'used', 'one', 'who', 'which', 'this',
+}
+
+
+class Candidate:
+    def __init__(self, synset_id: str, definition: str, is_instance: bool):
+        self.synset_id = synset_id
+        self.definition = definition
+        self.is_instance = is_instance
+        self.warnings: List[str] = []
+        self.hard_fails: List[str] = []
+        self.assigned_id: Optional[str] = None
+
+    @property
+    def accepted(self) -> bool:
+        return not self.hard_fails
+
+
+def load_ili_ids_and_definitions(ili_file: Path) -> Tuple[Set[str], List[Tuple[str, str]]]:
+    g = Graph()
+    g.parse(ili_file, format='ttl')
+    ids = set()
+    definitions = []
+    for subj, obj in g.subject_objects(predicate=SKOS.definition):
+        ili = subj.rpartition('/')[2]
+        ids.add(ili)
+        definitions.append((ili, str(obj)))
+    return ids, definitions
+
+
+def next_id_after(ids: Set[str]) -> int:
+    if not ids:
+        return 1
+    return max(int(i.lstrip('i')) for i in ids) + 1
+
+
+def looks_english(text: str) -> bool:
+    words = re.findall(r"[a-zA-Z']+", text.lower())
+    if not words:
+        return False
+    ascii_ratio = sum(c.isascii() for c in text) / len(text)
+    has_common_word = any(w in _COMMON_ENGLISH_WORDS for w in words)
+    return ascii_ratio > 0.9 and has_common_word
+
+
+def escape_turtle_string(text: str) -> str:
+    text = ' '.join(text.split())  # collapse whitespace/newlines to a single line
+    text = text.replace('\\', '\\\\').replace('"', '\\"')
+    return text
+
+
+def is_instance_synset(synset: wn.lmf.Synset) -> bool:
+    return any(r.get('relType') == 'instance_hypernym' for r in synset.get('relations', []))
+
+
+def extract_candidates(lex: wn.lmf.Lexicon) -> List[Candidate]:
+    candidates = []
+    for ss in lex.get('synsets', []):
+        if ss.get('ili') != 'in':
+            continue
+        ili_definition = ss.get('ili_definition')
+        definition = ili_definition['text'].strip() if ili_definition else ''
+        candidates.append(Candidate(ss['id'], definition, is_instance_synset(ss)))
+    return candidates
+
+
+def apply_structural_checks(lex: wn.lmf.Lexicon, candidates: List[Candidate]) -> None:
+    by_id = {c.synset_id: c for c in candidates}
+    report = wn.validate.validate(lex, select=STRUCTURAL_CHECKS, progress_handler=None)
+    for code in STRUCTURAL_CHECKS:
+        check = report.get(code)
+        if not check:
+            continue
+        for synset_id in check['items']:
+            candidate = by_id.get(synset_id)
+            if candidate is None:
+                continue
+            message = f'{code}: {check["message"]}'
+            if code in HARD_FAIL_CODES:
+                candidate.hard_fails.append(message)
+            else:
+                candidate.warnings.append(message)
+
+
+def apply_length_check(candidates: List[Candidate]) -> None:
+    for candidate in candidates:
+        if candidate.hard_fails:
+            continue  # already unusable (e.g. missing definition entirely)
+        length = len(candidate.definition)
+        if length < MIN_DEFINITION_LENGTH or length > MAX_DEFINITION_LENGTH:
+            candidate.hard_fails.append(
+                f'definition length ({length} chars) outside the expected '
+                f'{MIN_DEFINITION_LENGTH}-{MAX_DEFINITION_LENGTH} character range')
+
+
+def apply_english_heuristic(candidates: List[Candidate]) -> None:
+    for candidate in candidates:
+        if candidate.hard_fails:
+            continue
+        if not looks_english(candidate.definition):
+            candidate.warnings.append(
+                'definition does not look like English (heuristic check, may be a false positive)')
+
+
+def apply_similarity_check(
+    candidates: List[Candidate],
+    existing_definitions: List[Tuple[str, str]],
+    threshold: float,
+) -> None:
+    checkable = [c for c in candidates if not c.hard_fails]
+    if not checkable or not existing_definitions:
+        return
+
+    from sentence_transformers import SentenceTransformer, util
+
+    model = SentenceTransformer(MINILM_MODEL)
+    existing_ilis = [ili for ili, _ in existing_definitions]
+    existing_texts = [text for _, text in existing_definitions]
+    existing_embeddings = model.encode(
+        existing_texts, normalize_embeddings=True, convert_to_tensor=True, show_progress_bar=False)
+    candidate_embeddings = model.encode(
+        [c.definition for c in checkable], normalize_embeddings=True,
+        convert_to_tensor=True, show_progress_bar=False)
+
+    scores = util.cos_sim(candidate_embeddings, existing_embeddings)
+    for candidate, row in zip(checkable, scores):
+        best_score, best_index = float(row.max()), int(row.argmax())
+        if best_score >= threshold:
+            matched_ili = existing_ilis[best_index]
+            matched_text = existing_texts[best_index]
+            candidate.warnings.append(
+                f'possible duplicate of <{matched_ili}> (cosine similarity '
+                f'{best_score:.3f}): "{matched_text}"')
+
+
+def assign_ids(candidates: List[Candidate], next_id: int) -> None:
+    for candidate in candidates:
+        if candidate.accepted:
+            candidate.assigned_id = f'i{next_id}'
+            next_id += 1
+
+
+def render_fragment(candidates: List[Candidate], wn_url: str) -> str:
+    blocks = []
+    for candidate in candidates:
+        if not candidate.accepted:
+            continue
+        rdf_type = '<Instance>' if candidate.is_instance else '<Concept>'
+        definition = escape_turtle_string(candidate.definition)
+        source = f'{wn_url}{candidate.synset_id}'
+        blocks.append(
+            f'<{candidate.assigned_id}>\ta\t{rdf_type} ;\n'
+            f'\tskos:definition\t"{definition}"@en ;\n'
+            f'\tdc:source\t<{source}> ;\n'
+            f'\tili:status\tili:provisional .\n')
+    return '\n'.join(blocks)
+
+
+def render_report(candidates: List[Candidate], source_name: str) -> str:
+    accepted = [c for c in candidates if c.accepted]
+    failed = [c for c in candidates if not c.accepted]
+    lines = [
+        f'# ILI proposal report for {source_name}',
+        '',
+        f'{len(candidates)} candidate(s) found: {len(accepted)} accepted, '
+        f'{len(failed)} hard-failed.',
+        '',
+    ]
+    if accepted:
+        lines.append('## Accepted')
+        for c in accepted:
+            lines.append(f'- {c.assigned_id} (was {c.synset_id}): "{c.definition}"')
+            for warning in c.warnings:
+                lines.append(f'  - warning: {warning}')
+        lines.append('')
+    if failed:
+        lines.append('## Hard-failed (not included in the fragment)')
+        for c in failed:
+            lines.append(f'- {c.synset_id}: "{c.definition}"')
+            for reason in c.hard_fails:
+                lines.append(f'  - {reason}')
+        lines.append('')
+    return '\n'.join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Extract ILI candidates from a WN-LMF file into an ili.ttl-ready fragment.')
+    parser.add_argument('wordnet', type=Path, help='WN-LMF XML file to read')
+    parser.add_argument('wn_id', help='short id for the source wordnet, e.g. oewn')
+    parser.add_argument(
+        'wn_url', help='base URL used to build each dc:source IRI (synset id is appended), '
+                        'e.g. http://en-word.net/id/')
+    parser.add_argument('--ili-file', type=Path, default=Path('ili.ttl'),
+                         help='path to the current ili.ttl (default: ./ili.ttl)')
+    parser.add_argument('--report', type=Path, default=None,
+                         help='write the QC report here instead of stderr')
+    parser.add_argument('--similarity-threshold', type=float, default=DEFAULT_SIMILARITY_THRESHOLD,
+                         help='cosine similarity (0-1) above which an existing definition is '
+                              f'flagged as a possible duplicate (default: {DEFAULT_SIMILARITY_THRESHOLD})')
+    args = parser.parse_args()
+
+    try:
+        resource = wn.lmf.load(args.wordnet)
+    except wn.lmf.LMFError as exc:
+        sys.exit(f'{args.wordnet}: invalid WN-LMF file: {exc}')
+
+    lexicons = resource.get('lexicons', [])
+    if not lexicons:
+        sys.exit(f'{args.wordnet}: no lexicons found')
+    if len(lexicons) > 1:
+        print(f'note: {args.wordnet} contains {len(lexicons)} lexicons; '
+              'only the first is processed', file=sys.stderr)
+    lex = lexicons[0]
+
+    existing_ids, existing_definitions = load_ili_ids_and_definitions(args.ili_file)
+    next_id = next_id_after(existing_ids)
+
+    candidates = extract_candidates(lex)
+    if not candidates:
+        print(f'no ili="in" synsets found in {args.wordnet}', file=sys.stderr)
+        return
+
+    apply_structural_checks(lex, candidates)
+    apply_length_check(candidates)
+    apply_english_heuristic(candidates)
+    apply_similarity_check(candidates, existing_definitions, args.similarity_threshold)
+    assign_ids(candidates, next_id)
+
+    fragment = render_fragment(candidates, args.wn_url)
+    if fragment:
+        print(fragment)
+
+    report = render_report(candidates, args.wordnet.name)
+    if args.report:
+        args.report.write_text(report)
+    else:
+        print(report, file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 isodate==0.6.1
 pyparsing==3.0.9
 rdflib==6.2.0
+sentence-transformers==5.6.0
 six==1.16.0
+wn==1.1.0

--- a/validate-ili-proposal.py
+++ b/validate-ili-proposal.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+
+"""
+Script that generates the CI comment for an ILI-proposal pull request
+(issue #9, Phase 2). Invoked by
+.github/workflows/validate-ili-proposal.yml; not meant to be run by
+contributors themselves (see propose-ili.py for that).
+
+Unlike propose-ili.py, this script never sees the contributor's original
+WN-LMF file - a pull_request CI job only has the git history, so it only
+has two versions of ili.ttl: the PR's target branch, and the PR's own
+branch. It:
+
+  1. Uses `git diff` to find which <iNNNNN> subjects this PR's commits
+     actually added (not a graph-level set difference - see the note on
+     collisions below for why that matters).
+  2. Checks each added subject's shape (correct rdf:type, an @en
+     skos:definition, dc:source, ili:status ili:provisional).
+  3. Flags an added id that already exists on the target branch as a
+     collision: two proposal PRs opened around the same time can both
+     compute the same next-available id, and because both diffs are
+     pure appends, git won't necessarily flag this as a merge conflict
+     on its own (see PROPOSING_ILIS.md).
+  4. Re-runs the semantic duplicate check (MiniLM cosine similarity)
+     against every definition already on the target branch.
+
+Renders one Markdown comment, meant to be posted (or, on a later push,
+updated in place) on the pull request.
+
+Requirements:
+    - Python 3.6+
+    - rdflib
+    - sentence-transformers
+Usage:
+    python3 validate-ili-proposal.py --base-ili BASE_ILI.ttl \
+        --diff DIFF_FILE --head-ili ili.ttl [--output comment.md]
+
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from rdflib import Graph, Namespace
+from rdflib.namespace import RDF, SKOS, DC
+
+ILI = Namespace('http://globalwordnet.org/ili/')
+STATUS = Namespace('https://globalwordnet.github.io/cili/ontology.xml#')
+MARKER = '<!-- ili-validation-report -->'
+MINILM_MODEL = 'sentence-transformers/all-MiniLM-L6-v2'
+DEFAULT_SIMILARITY_THRESHOLD = 0.95
+
+# matches the start of a concept block, e.g. `<i117660>\ta\t<Concept> ;`
+# (the exact format propose-ili.py emits) on a line the diff *added*.
+ADDED_SUBJECT_RE = re.compile(r'^\+<(i\d+)>\s+a\s+')
+# a removed line, excluding the `--- a/...` unified-diff file header
+# (content lines are tab-indented, so `-\S` alone would miss most of them)
+REMOVED_CONTENT_RE = re.compile(r'^-(?!--)')
+
+
+def load_entries(ttl_path: Path) -> Dict[str, Dict]:
+    g = Graph()
+    g.parse(ttl_path, format='ttl')
+    entries = {}
+    for subj in g.subjects(RDF.type, None):
+        rdf_type = g.value(subj, RDF.type)
+        if rdf_type not in (ILI.Concept, ILI.Instance):
+            continue
+        sid = subj.rpartition('/')[2]
+        entries[sid] = {
+            'type': rdf_type,
+            'definition': g.value(subj, SKOS.definition),
+            'source': g.value(subj, DC.source),
+            'status': g.value(subj, STATUS.status),
+        }
+    return entries
+
+
+def added_ids_from_diff(diff_text: str) -> Tuple[List[str], bool]:
+    """Returns (ids added by this PR's diff, whether anything else was removed)."""
+    added = []
+    removed_other_content = False
+    for line in diff_text.splitlines():
+        m = ADDED_SUBJECT_RE.match(line)
+        if m:
+            added.append(m.group(1))
+        elif REMOVED_CONTENT_RE.match(line) and not line.startswith('---'):
+            removed_other_content = True
+    return added, removed_other_content
+
+
+def shape_errors_for(entry: Dict) -> List[str]:
+    errors = []
+    if entry['type'] not in (ILI.Concept, ILI.Instance):
+        errors.append('missing or invalid `a <Concept>`/`<Instance>`')
+    definition = entry['definition']
+    if definition is None or getattr(definition, 'language', None) != 'en':
+        errors.append('missing or non-`@en` `skos:definition`')
+    if entry['source'] is None:
+        errors.append('missing `dc:source`')
+    if entry['status'] != STATUS.provisional:
+        errors.append('missing `ili:status ili:provisional`')
+    return errors
+
+
+def find_duplicates(
+    added_ids: List[str],
+    head_entries: Dict[str, Dict],
+    base_entries: Dict[str, Dict],
+    threshold: float,
+) -> Dict[str, Tuple[str, str, float]]:
+    checkable = [sid for sid in added_ids if head_entries[sid]['definition'] is not None]
+    base_with_defs = [(sid, e['definition']) for sid, e in base_entries.items() if e['definition'] is not None]
+    if not checkable or not base_with_defs:
+        return {}
+
+    from sentence_transformers import SentenceTransformer, util
+
+    model = SentenceTransformer(MINILM_MODEL)
+    base_ids = [sid for sid, _ in base_with_defs]
+    base_texts = [str(defn) for _, defn in base_with_defs]
+    base_embeddings = model.encode(
+        base_texts, normalize_embeddings=True, convert_to_tensor=True, show_progress_bar=False)
+    candidate_texts = [str(head_entries[sid]['definition']) for sid in checkable]
+    candidate_embeddings = model.encode(
+        candidate_texts, normalize_embeddings=True, convert_to_tensor=True, show_progress_bar=False)
+
+    scores = util.cos_sim(candidate_embeddings, base_embeddings)
+    results = {}
+    for sid, row in zip(checkable, scores):
+        best_score, best_index = float(row.max()), int(row.argmax())
+        if best_score >= threshold:
+            results[sid] = (base_ids[best_index], base_texts[best_index], best_score)
+    return results
+
+
+def render_comment(
+    added_ids: List[str],
+    head_entries: Dict[str, Dict],
+    base_entries: Dict[str, Dict],
+    shape_problems: Dict[str, List[str]],
+    collisions: List[str],
+    removed_other_content: bool,
+    duplicates: Dict[str, Tuple[str, str, float]],
+) -> str:
+    lines = [MARKER, '## ILI proposal validation', '']
+
+    if not added_ids:
+        lines.append(
+            'No new `<iNNNNN>` concepts were added by this diff (relative to the target branch), '
+            'so there is nothing for this check to validate.')
+        return '\n'.join(lines)
+
+    status_bits = []
+    status_bits.append('❌ shape errors' if shape_problems else '✅ shape checks passed')
+    status_bits.append('❌ ID collisions with target branch' if collisions else '✅ no ID collisions with target branch')
+    status_bits.append(f'⚠️ {len(duplicates)} flagged for possible duplication' if duplicates
+                        else '✅ no likely duplicates found')
+    lines.append(f'{len(added_ids)} candidate(s) in this diff. ' + ' · '.join(status_bits))
+    lines.append('')
+
+    if removed_other_content:
+        lines.append(
+            '> ⚠️ This diff also removes or modifies existing lines in `ili.ttl`, not just appends '
+            'new concepts. Please double-check nothing outside the new proposals was touched.')
+        lines.append('')
+
+    if collisions:
+        lines.append(f'### {len(collisions)} ID collision(s)')
+        lines.append(
+            'These ids were added by this PR but already exist on the target branch - likely '
+            'because another proposal PR merged first. Rerun `propose-ili.py` against the latest '
+            'target branch and push again; it always allocates from the current file.')
+        lines.append('')
+        for sid in collisions:
+            lines.append(f'- `{sid}`')
+        lines.append('')
+
+    if shape_problems:
+        lines.append(f'### {len(shape_problems)} shape error(s)')
+        lines.append('')
+        for sid, errs in shape_problems.items():
+            lines.append(f'- `{sid}`: ' + '; '.join(errs))
+        lines.append('')
+
+    if duplicates:
+        lines.append(f'<details>')
+        lines.append(
+            f'<summary>{len(duplicates)} candidate(s) flagged as possible duplicates '
+            f'(cosine similarity ≥ threshold against an existing ILI)</summary>')
+        lines.append('')
+        lines.append('| New ID | Proposed definition | Similarity | Existing ID | Existing definition |')
+        lines.append('|---|---|---|---|---|')
+        for sid, (match_id, match_text, score) in sorted(duplicates.items(), key=lambda kv: -kv[1][2]):
+            new_defn = str(head_entries[sid]['definition'])
+            lines.append(f'| `{sid}` | "{new_defn}" | {score:.3f} | `{match_id}` | "{match_text}" |')
+        lines.append('')
+        lines.append('</details>')
+        lines.append('')
+
+    clean_count = len(added_ids) - len(shape_problems) - len(duplicates)
+    if clean_count > 0:
+        lines.append(f'The remaining {clean_count} candidate(s) passed all diff-checkable validation with no flags.')
+        lines.append('')
+
+    lines.append(
+        'This is advisory, not blocking - a high similarity score is a prompt for reviewer '
+        'judgment, not proof of duplication. Some checks the contributor\'s local `propose-ili.py` '
+        'run performs (structural WN-LMF checks, the English-language heuristic, and in-submission '
+        'duplicate detection) require the original wordnet file and cannot be re-run here - see the '
+        'PR description\'s QC report for those. See [PROPOSING_ILIS.md](PROPOSING_ILIS.md) for '
+        'details.')
+    lines.append('')
+    lines.append('*Posted automatically on push. Re-runs replace this comment.*')
+    return '\n'.join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Generate the CI validation comment for an ILI-proposal pull request.')
+    parser.add_argument('--base-ili', type=Path, required=True,
+                         help="ili.ttl as it exists on the PR's target branch")
+    parser.add_argument('--head-ili', type=Path, default=Path('ili.ttl'),
+                         help="ili.ttl as it exists on the PR's own branch (default: ./ili.ttl)")
+    parser.add_argument('--diff', type=Path, required=True,
+                         help='a `git diff` of ili.ttl between the target branch and this PR')
+    parser.add_argument('--output', type=Path, default=None,
+                         help='write the comment here (default: stdout)')
+    parser.add_argument('--similarity-threshold', type=float, default=DEFAULT_SIMILARITY_THRESHOLD)
+    args = parser.parse_args()
+
+    base_entries = load_entries(args.base_ili)
+    head_entries = load_entries(args.head_ili)
+
+    added_ids, removed_other_content = added_ids_from_diff(args.diff.read_text())
+    added_ids = [sid for sid in added_ids if sid in head_entries]  # defensive: only known subjects
+
+    collisions = [sid for sid in added_ids if sid in base_entries]
+    non_colliding = [sid for sid in added_ids if sid not in base_entries]
+
+    shape_problems = {}
+    for sid in non_colliding:
+        errors = shape_errors_for(head_entries[sid])
+        if errors:
+            shape_problems[sid] = errors
+
+    duplicates = find_duplicates(non_colliding, head_entries, base_entries, args.similarity_threshold)
+
+    comment = render_comment(
+        added_ids, head_entries, base_entries, shape_problems, collisions,
+        removed_other_content, duplicates)
+
+    if args.output:
+        args.output.write_text(comment)
+    else:
+        print(comment)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Phase 1 of the workflow discussed in #9: propose new ILI concepts as ordinary GitHub PRs against `ili.ttl` instead of the current informal offline process.

**Depends on #24** (base of this PR) — new candidates are stamped `ili:status ili:provisional`, which needs #24's vocabulary/namespace work merged first. Once #24 merges, this PR's base should be retargeted to `master`.

## What's here

- `propose-ili.py`: takes a contributor's WN-LMF file, extracts `ili="in"` candidates via `wn.lmf.load`, runs `wn`'s own structural validation as hard-fail checks (missing/blank definitions, non-unique ids, in-file duplicates), adds CILI-specific checks (definition length; an English-language heuristic, warning-only; and a semantic duplicate check against every existing `ili.ttl` definition using MiniLM sentence embeddings, warning-only, default cosine-similarity threshold 0.95), allocates sequential `iNNNNN` ids, and emits an `ili.ttl`-ready Turtle fragment plus a QC report meant to go straight into the PR description.
- `PROPOSING_ILIS.md`: contributor-facing (how to run the script, PR-size guidance per @jmccrae's comment on #9) and maintainer-facing (how to read the report, ID-collision handling, the manual provisional→active promotion sweep) documentation.
- `requirements.txt`: adds `wn` and `sentence-transformers`. Flagging plainly — the latter pulls in PyTorch, a real, visible increase in dependency footprint compared to today's four lightweight packages. Also fixes a pre-existing gap: `tab-to-ttl.py` already used `wn` without it being declared here.
- `make-html.py`: fixes a latent crash this feature would otherwise trigger immediately — `source_info()` only recognized PWN 3.0 as a `dc:source` and raised, killing the *entire* site build, on anything else. Since this feature explicitly enables proposals from any wordnet, that's no longer hypothetical; it now falls back to a generic source label instead of crashing.

## On the similarity threshold

Calibrated this against real `ili.ttl` definitions rather than assuming a number: at MiniLM's scale, a 0.95 cosine-similarity threshold mostly catches near-verbatim or lightly-reworded reuse (e.g. a synonym swap — scored ~0.96 in testing) — genuine paraphrases with different structure can score well below that (~0.68 in one test). Kept the 0.95 default as requested, but documented this plainly in `PROPOSING_ILIS.md` so a high score isn't over-trusted and a low one isn't taken as proof of novelty.

## Verification

- Hand-built a synthetic WN-LMF fixture covering 5 cases (clean candidate, too-short definition, exact duplicate, lightly-reworded duplicate, missing `<ILIDefinition>`) and confirmed `propose-ili.py` produces the correct fragment and report for each.
- Confirmed the emitted fragment, appended to the real `ili.ttl`, still parses cleanly with `rdflib` and that `ili:status` resolves correctly under the ontology namespace from #24.
- Ran `make-html.py` end-to-end against the appended file (117,665 pages) to confirm the site build no longer crashes on a non-PWN30 source, and spot-checked both a new provisional page and an existing PWN30 page for correctness.

## Not in this PR (tracked as follow-up in #9)

- CI automation that re-validates proposal PRs and comments on them (Phase 2).
- Naisc-based taxonomic-neighbor comparison.
- Automated provisional→active promotion.