### PR TITLE
Fix CI comment posting (-f vs -F) + ignore proposed.ttl

### DIFF
--- a/.github/workflows/validate-ili-proposal.yml
+++ b/.github/workflows/validate-ili-proposal.yml
@@ -63,7 +63,7 @@ jobs:
             --jq "[.[] | select(.body | startswith(\"$MARKER\"))] | last | .id // empty")
 
           if [ -n "$COMMENT_ID" ]; then
-            gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -f body=@/tmp/comment.md
+            gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -F body=@/tmp/comment.md
           else
-            gh api "repos/$REPO/issues/$PR_NUMBER/comments" -X POST -f body=@/tmp/comment.md
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" -X POST -F body=@/tmp/comment.md
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ env
 tmp
 docs
 .env
+proposed.ttl


### PR DESCRIPTION
## Summary
- Fixes the bug from PR #28: `validate-ili-proposal.yml` used `gh api ... -f body=@/tmp/comment.md`, but `-f`/`--raw-field` treats its value as a literal string. Only `-F`/`--field` has the `@filename` file-read magic. The comment posted was literally the text `@/tmp/comment.md`. Switched both the PATCH and POST calls to `-F`.
- Adds `proposed.ttl` to `.gitignore` (the output filename used in `propose-ili.py`'s own usage examples), so a contributor's local output file doesn't get committed by accident.

## Test plan
- [x] Verified locally against the real repo: posted a comment with `-F body=@file` and confirmed it correctly read the file's contents (then deleted the test comment).
- [ ] Push a trivial commit to PR #28 to confirm the live workflow now posts a real comment.