### PR TITLE
Update the namespace

### DIFF
--- a/VOCABULARY.md
+++ b/VOCABULARY.md
@@ -69,19 +69,19 @@ by two separate `ili.ttl` prefix declarations:
 
 ```turtle
 @prefix ili: <https://globalwordnet.github.io/cili/ontology.xml#> .
-@base <http://globalwordnet.org/ili/> .
+@base <http://globalwordnet.org/cili/> .
 ```
 
 * Concept IDs (`<i123>`, and the existing `<Concept>`/`<Instance>` classes)
   stay exactly as they are today, relative to `@base`, i.e.
-  `http://globalwordnet.org/ili/i123`. Nothing about any existing concept's
+  `http://globalwordnet.org/cili/i123`. Nothing about any existing concept's
   URI changes.
 * The new vocabulary terms — `ili:status`, `ili:supersededBy`, and the
   status values `ili:provisional`/`ili:active`/`ili:deprecated` — are
   prefixed with `ili:`, which now points at
   `https://globalwordnet.github.io/cili/ontology.xml#`, a real,
   dereferenceable document ([`ontology.xml`](ontology.xml), published via
-  GitHub Pages), rather than `http://globalwordnet.org/ili/`, which does
+  GitHub Pages), rather than `http://globalwordnet.org/cili/`, which does
   not currently resolve.
 
 This also settles the namespace-collision concern @goodmami raised in
@@ -103,7 +103,7 @@ The IDs below are placeholders, not references to real ILI concepts:
 
 ```turtle
 @prefix ili: <https://globalwordnet.github.io/cili/ontology.xml#> .
-@base <http://globalwordnet.org/ili/> .
+@base <http://globalwordnet.org/cili/> .
 
 <iXXXXX> a <Concept> ;
     skos:definition "..."@en ;

--- a/ili-map-odwn13.ttl
+++ b/ili-map-odwn13.ttl
@@ -6,8 +6,8 @@
 
 ### this file
 
-@prefix ili: <http://globalwordnet.org/ili/> .
-@base <http://globalwordnet.org/ili/ili-map.ttl>.
+@prefix ili: <http://globalwordnet.org/cili/> .
+@base <http://globalwordnet.org/cili/ili-map.ttl>.
 
 ili:i69801	owl:sameAs	odwn13:06341431-n . # mevr.
 ili:i115080	owl:sameAs	odwn13:14848149-n . # eluens

--- a/ili-map-wn30.ttl
+++ b/ili-map-wn30.ttl
@@ -6,8 +6,8 @@
 
 ### This file
 
-@prefix ili: <http://globalwordnet.org/ili/> .
-@base <http://globalwordnet.org/ili/ili-map.ttl>.
+@prefix ili: <http://globalwordnet.org/cili/> .
+@base <http://globalwordnet.org/cili/ili-map.ttl>.
 
 <i1>	owl:sameAs	pwn30:00001740-a . # able
 <i2>	owl:sameAs	pwn30:00002098-a . # unable

--- a/ili-map-wn31.ttl
+++ b/ili-map-wn31.ttl
@@ -1,6 +1,6 @@
 @prefix owl:    <http://www.w3.org/2002/07/owl#> .
 @prefix pwn31: <http://wordnet-rdf.princeton.edu/wn31/> .
-@prefix ili: <http://globalwordnet.org/ili/> .
+@prefix ili: <http://globalwordnet.org/cili/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
 ili:i1 owl:sameAs pwn31:300001740-a . # able

--- a/ili-map.ttl
+++ b/ili-map.ttl
@@ -6,8 +6,8 @@
 
 ### This file
 
-@prefix ili: <http://globalwordnet.org/ili/> .
-@base <http://globalwordnet.org/ili/ili-map.ttl>.
+@prefix ili: <http://globalwordnet.org/cili/> .
+@base <http://globalwordnet.org/cili/ili-map.ttl>.
 
 <i1>	owl:sameAs	pwn30:00001740-a . # able
 <i2>	owl:sameAs	pwn30:00002098-a . # unable

--- a/ili.ttl
+++ b/ili.ttl
@@ -15,11 +15,11 @@
 ### Concept identifiers (below) are unaffected: they stay relative to @base.
 @prefix ili: <https://globalwordnet.github.io/cili/ontology.xml#> .
 
-@base <http://globalwordnet.org/ili/> .
+@base <http://globalwordnet.org/cili/> .
 
 <https://globalwordnet.github.io/cili/ili.ttl> a voaf:Vocabulary ;
   vann:preferredNamespacePrefix "ili" ;
-  vann:preferredNamespaceUri "http://globalwordnet.org/ili/" ;
+  vann:preferredNamespaceUri "http://globalwordnet.org/cili/" ;
   dc:title "Global Wordnet ILI"@en ;
   dc:description "The shared Inter-Lingual Index for the global wordnets.  It consists of a list of concepts of instances with defintions, and their links to open wordnets."@en ;
   dc:issued "2016-01-26"^^xsd:date ;

--- a/make-html.py
+++ b/make-html.py
@@ -135,7 +135,7 @@ article = '''\
   </article>
 '''
 
-ILI = Namespace('http://globalwordnet.org/ili/')
+ILI = Namespace('http://globalwordnet.org/cili/')
 STATUS = Namespace('https://globalwordnet.github.io/cili/ontology.xml#')
 
 sources = {

--- a/ontology.xml
+++ b/ontology.xml
@@ -10,7 +10,7 @@
 
   <owl:Ontology rdf:about="https://globalwordnet.github.io/cili/ontology.xml">
     <dc:title xml:lang="en">CILI Status Vocabulary</dc:title>
-    <dc:description xml:lang="en">Vocabulary for annotating the status of an ILI concept (provisional, active, deprecated) and recording supersession, as discussed in https://github.com/globalwordnet/cili/issues/8. Concept identifiers themselves (ili:i1, ili:i2, ...) are not defined here; they remain under http://globalwordnet.org/ili/, as declared in ili.ttl.</dc:description>
+    <dc:description xml:lang="en">Vocabulary for annotating the status of an ILI concept (provisional, active, deprecated) and recording supersession, as discussed in https://github.com/globalwordnet/cili/issues/8. Concept identifiers themselves (ili:i1, ili:i2, ...) are not defined here; they remain under http://globalwordnet.org/cili/, as declared in ili.ttl.</dc:description>
     <vann:preferredNamespacePrefix>ili</vann:preferredNamespacePrefix>
     <vann:preferredNamespaceUri>https://globalwordnet.github.io/cili/ontology.xml#</vann:preferredNamespaceUri>
   </owl:Ontology>
@@ -24,8 +24,8 @@
   <owl:ObjectProperty rdf:about="#supersededBy">
     <rdfs:label xml:lang="en">superseded by</rdfs:label>
     <rdfs:comment xml:lang="en">Links a deprecated ILI concept to the concept(s) that replace it. May be repeated on the same subject to represent a split into multiple concepts.</rdfs:comment>
-    <rdfs:domain rdf:resource="http://globalwordnet.org/ili/Concept"/>
-    <rdfs:range rdf:resource="http://globalwordnet.org/ili/Concept"/>
+    <rdfs:domain rdf:resource="http://globalwordnet.org/cili/Concept"/>
+    <rdfs:range rdf:resource="http://globalwordnet.org/cili/Concept"/>
   </owl:ObjectProperty>
 
   <owl:Class rdf:about="#Status">

--- a/tab-to-ttl.py
+++ b/tab-to-ttl.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
 
     print("@prefix owl:    <http://www.w3.org/2002/07/owl#> .")
     print(f"@prefix {wn_id}: <{wn_url}> .")
-    print("@prefix ili: <http://globalwordnet.org/ili/> .")
+    print("@prefix ili: <http://globalwordnet.org/cili/> .")
     print("@prefix skos: <http://www.w3.org/2004/02/skos/core#> .")
     print()
 

--- a/validate-ili-proposal.py
+++ b/validate-ili-proposal.py
@@ -46,7 +46,7 @@ from typing import Dict, List, Optional, Tuple
 from rdflib import Graph, Namespace
 from rdflib.namespace import RDF, SKOS, DC
 
-ILI = Namespace('http://globalwordnet.org/ili/')
+ILI = Namespace('http://globalwordnet.org/cili/')
 STATUS = Namespace('https://globalwordnet.github.io/cili/ontology.xml#')
 MARKER = '<!-- ili-validation-report -->'
 MINILM_MODEL = 'sentence-transformers/all-MiniLM-L6-v2'


### PR DESCRIPTION
The namespace for the ILI was previously http://globalwordnet.org/ili/ which doesn't work as this repo is now named `cili`. This PR simply updates the URL to http://globalwordnet.org/cili